### PR TITLE
Can get the next review page url again. It seemed to have been broken

### DIFF
--- a/amazon_scraper/reviews.py
+++ b/amazon_scraper/reviews.py
@@ -1,7 +1,10 @@
 from __future__ import absolute_import
 import re
 import requests
+from urlparse import urljoin
+
 from bs4 import BeautifulSoup
+
 from amazon_scraper import review_url, reviews_url, extract_review_id, dict_acceptable, retry, rate_limit, extract_reviews_id, user_agent
 
 
@@ -57,9 +60,9 @@ class Reviews(object):
     @property
     def next_page_url(self):
         # lazy loading causes this to differ from the HTML visible in chrome
-        anchor = self.soup.find('a', text=re.compile(ur'next', flags=re.I))
+        anchor = self.soup.find('a', href=re.compile(r'next'))
         if anchor:
-            return unicode(anchor['href'])
+            return urljoin("http://www.amazon.com", unicode(anchor['href']))
         return None
 
     @property


### PR DESCRIPTION
The amazon html looks like this now: 
```
<a href="/Learning-Python-Edition-Mark-Lutz/product-reviews/1449355730/ref=cm_cr_pr_btm_link_next_3?ie=UTF8&amp;formatType=all_formats&amp;sortBy=recent&amp;filterByStar=all_stars&amp;pageSize=10&amp;pageNumber=3&amp;reviewerType=all_reviews">
Next
   <span class="a-letter-space"></span>
   <span class="a-letter-space"></span>
→
</a>
```
For some reason searching by text does not work and actually only returns the text and not the anchor it is attached to. So instead I decided to search by href