### PR TITLE
Allow iterating over review pages and improve url returns

### DIFF
--- a/amazon_scraper/reviews.py
+++ b/amazon_scraper/reviews.py
@@ -16,12 +16,13 @@ class Reviews(object):
                 raise ValueError('URL passed as ASIN')
 
             URL = reviews_url(ItemId)
+        elif URL and 'product-reviews' in URL:  # This is probably a valid product review page. Let it be.
+            URL = URL
+        elif URL:
+            # cleanup the url
+            URL = reviews_url(extract_reviews_id(URL))
         else:
-            if URL:
-                # cleanup the url
-                URL = reviews_url(extract_reviews_id(URL))
-        if not URL:
-            raise ValueError('Invalid review page parameters')
+            raise ValueError('Invalid review page parameters. Input a URL or a valid ASIN!')
 
         self.api = api
         self._URL = URL
@@ -55,7 +56,7 @@ class Reviews(object):
 
     @property
     def url(self):
-        return reviews_url(self.asin)
+        return self._URL
 
     @property
     def next_page_url(self):

--- a/amazon_scraper/reviews.py
+++ b/amazon_scraper/reviews.py
@@ -16,9 +16,7 @@ class Reviews(object):
                 raise ValueError('URL passed as ASIN')
 
             URL = reviews_url(ItemId)
-        elif URL and 'product-reviews' in URL:  # This is probably a valid product review page. Let it be.
-            URL = URL
-        elif URL:
+        elif URL and 'product-reviews' not in URL:  # If product-reviews in the url it's probably a valid product review page. Let it be.
             # cleanup the url
             URL = reviews_url(extract_reviews_id(URL))
         else:


### PR DESCRIPTION
We couldn't page over to the next review url by doing:
```
new_reviews = amazon.reviews(URL=old_reviews.next_page_url)
```
because the new reviews url would instantly revert back to the way we were handling the old one. Also since we bothered doing some cleanup on the init method I noticed we could improve the way we were returning the url property by just returning self._URL.