### PR TITLE
Add review batch parsing.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,7 @@ tests/config.json
 
 # python
 *.py[co]
+*.rope
 
 # Packages
 *.egg

--- a/README.rst
+++ b/README.rst
@@ -49,9 +49,11 @@ Installation
     pip install amazon_scraper
 
 
-Example
-=======
+Examples
+========
 
+All Products All The Time
+~~~~~~~~~~~~~~~~~~~~~~~~~
 Create an API instance::
 
     >>> from amazon_scraper import AmazonScraper
@@ -134,6 +136,8 @@ Supplemental text not available via the API::
     [u"Bob Howard is a computer-hacker desk jockey ... ", u"Lovecraft\'s Cthulhu meets Len Deighton\'s spies ... ", u"This dark, funny blend of SF and ... "]
 
 
+Review API
+~~~~~~~~~~
 View lists of reviews::
 
     >>> p = amzn.lookup(ItemId='B0051QVF7A')
@@ -145,7 +149,16 @@ View lists of reviews::
     >>> rs.url
     http://www.amazon.com/product-reviews/B0051QVF7A/ref=cm_cr_pr_top_sort_recent?&sortBy=bySubmissionDateDescending
 
+Quickly get a list of all reviews on a review page using `parse_reviews_on_page`::
 
+    >>> p = amzn.lookup(ItemId='B0051QVF7A')
+    >>> rs = amzn.reviews(URL=p.reviews_url)
+    >>> all_reviews_on_page = rs.parse_reviews_on_page()
+    >>> len(all_reviews_on_page)
+    10
+    >>> all_reviews_on_page[0].to_dict()["title"]
+    'Fantastic device - pick your Kindle!'
+    
 By ASIN/ItemId::
 
     >>> rs = amzn.reviews(ItemId='B0051QVF7A')
@@ -155,7 +168,8 @@ By ASIN/ItemId::
     ['R3MF0NIRI3BT1E', 'R3N2XPJT4I1XTI', 'RWG7OQ5NMGUMW', 'R1FKKJWTJC4EAP', 'RR8NWZ0IXWX7K', 'R32AU655LW6HPU', 'R33XK7OO7TO68E', 'R3NJRC6XH88RBR', 'R21JS32BNNQ82O', 'R2C9KPSEH78IF7']
 
 
-Individual reviews::
+For individual reviews use the `review` method. As a note this method is **NOT** suggested
+for use in bulk collection of reviews. Use `parse_reviews_on_page` instead.::
 
     >>> r = amzn.review(Id=rs.ids[0])
     >>> r.id

--- a/amazon_scraper/__init__.py
+++ b/amazon_scraper/__init__.py
@@ -13,6 +13,7 @@ import time
 import requests
 from HTMLParser import HTMLParser
 from amazon.api import AmazonAPI
+import dateutil.parser
 from bs4 import BeautifulSoup
 
 log = logging.getLogger(__name__)
@@ -74,6 +75,14 @@ def add_query(url, **kwargs):
     query_params.update(kwargs)
     query_string = urllib.urlencode(query_params, doseq=True)
     return urlparse.urlunsplit((scheme, netloc, path, query_string, fragment))
+
+
+def get_review_date(raw_date):
+    string = unicode(raw_date)
+    # 2011-11-07T05:50:41Z
+    date = dateutil.parser.parse(string)
+    return date
+
 
 def strip_html_tags(html):
     if html:
@@ -176,4 +185,3 @@ class AmazonScraper(object):
     def search_n(self, n, **kwargs):
         for p in self.api.search_n(n, **kwargs):
             yield Product(p)
-

--- a/amazon_scraper/product.py
+++ b/amazon_scraper/product.py
@@ -15,7 +15,9 @@ class Product(object):
         self._soup = None
 
     def __getattr__(self, name):
-        # allow direct access to the product object
+        """
+        Allow direct access to the product object
+        """
         return getattr(self.product, name)
 
     @property
@@ -249,6 +251,6 @@ class Product(object):
         d.update({
             k:getattr(self, k)
             for k in dir(self)
-            if dict_acceptable(self, k, blacklist=['soup', 'api'])
+            if dict_acceptable(self, k, blacklist=['soup', 'api', 'ratings'])
         })
         return d

--- a/amazon_scraper/review.py
+++ b/amazon_scraper/review.py
@@ -1,8 +1,17 @@
 from __future__ import absolute_import
 import requests
-import dateutil.parser
 from bs4 import BeautifulSoup
-from amazon_scraper import review_url, extract_review_id, process_rating, strip_html_tags, dict_acceptable, retry, rate_limit, user_agent
+from amazon_scraper import (
+    review_url,
+    extract_review_id,
+    process_rating,
+    strip_html_tags,
+    dict_acceptable,
+    retry,
+    rate_limit,
+    user_agent,
+    get_review_date,
+)
 
 
 class Review(object):
@@ -69,10 +78,7 @@ class Review(object):
     @property
     def date(self):
         abbr = self.soup.find('abbr', class_='dtreviewed')
-        string = unicode(abbr['title'])
-        # 2011-11-07T05:50:41Z
-        date = dateutil.parser.parse(string)
-        return date
+        return get_review_date(abbr["title"])
 
     @property
     def author(self):

--- a/amazon_scraper/reviews.py
+++ b/amazon_scraper/reviews.py
@@ -24,7 +24,7 @@ class SubReview(object):
     This object is different than the one in review.py because the reviews on the
     'reviews' page have a different HTML format. Thus we must parse them differently
     """
-    def __init__(self, reviews_soup, review_id):
+    def __init__(self, reviews_soup, review_id, product_asin):
         self.soup = reviews_soup.find("div", id=review_id)
         if not self.soup:
             warnings.warn(
@@ -33,6 +33,7 @@ class SubReview(object):
             )
             raise ValueError()
 
+        self._asin = product_asin
         self._author = None
         self._date = None
         self._rating = None
@@ -49,6 +50,10 @@ class SubReview(object):
             else:
                 var = tmp
         return var
+
+    @property
+    def asin(self):
+        return self._asin
 
     @property
     def author(self):
@@ -93,6 +98,7 @@ class SubReview(object):
 
     def to_dict(self):
         return {
+            "asin": self.asin,
             "author": self.author,
             "date": self.date,
             "id": self.id,
@@ -127,7 +133,7 @@ class Reviews(object):
     def parse_reviews_on_page(self):
         for review_id in self.ids:
             try:
-                review = SubReview(self.soup, review_id)
+                review = SubReview(self.soup, review_id, self.asin)
             except ValueError:
                 continue
             self.all_reviews.append(review)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,2 @@
-python-amazon-simple-product-api
-xmltodict
-python-dateutil
-beautifulsoup4
-requests
-html5lib
+-e git+https://github.com/yoavaviram/python-amazon-simple-product-api.git#egg=python-amazon-simple-product-api
+-e .

--- a/setup.py
+++ b/setup.py
@@ -22,10 +22,10 @@ setup(
     url='https://github.com/adamlwgriffiths/amazon_scraper',
     test_suite='tests',
     packages=['amazon_scraper'],
-    requires=[
-        'pythonamazonsimpleproductapi',
+    install_requires=[
+        'python-amazon-simple-product-api',
         'xmltodict',
-        'pythondateutil',
+        'python-dateutil',
         'beautifulsoup4',
         'requests',
     ],

--- a/tests/test_reviews.py
+++ b/tests/test_reviews.py
@@ -3,17 +3,28 @@ import unittest
 import os
 from tests import AmazonTestCase
 
-class SearchTestCase(AmazonTestCase):
+class ReviewsTestCase(AmazonTestCase):
+    def test_parse_reviews_on_page(self):
+        p = self.amzn.lookup(ItemId="B0051QVF7A")
+        revs = self.amzn.reviews(URL=p.reviews_url)
+        all_reviews = revs.parse_reviews_on_page()
+        assert len(all_reviews), 10
+
+        # Ensure all review ids are represented
+        revs_ids = set(revs.ids)
+        all_reviews_ids = set([dict_.to_dict()["id"] for dict_ in all_reviews])
+        assert revs_ids == all_reviews_ids
+
+        # Ensure everything is found properly we don't really care about values though
+        for dict_ in all_reviews:
+            assert None not in dict_.to_dict().values()
+
     def test_reviews(self):
         p = self.amzn.lookup(ItemId='B0051QVF7A')
-        rs = self.amzn.reviews(URL=p.reviews_url)
-        rs.to_dict()
-        assert len(list(rs.ids))
-        assert rs.asin in ['B0051QVF7A', 'B00492CIC8']
-
-        r = self.amzn.review(Id=rs.ids[0])
-        r.to_dict()
-        assert r.asin in ['B0051QVF7A', 'B00492CIC8'], r.asin
+        revs = self.amzn.reviews(URL=p.reviews_url)
+        revs.to_dict()
+        assert len(list(revs.ids))
+        assert revs.asin == 'B0051QVF7A', revs.asin
 
     def test_reviews_asin(self):
         rs = self.amzn.reviews(ItemId='B0051QVF7A')

--- a/tests/test_reviews.py
+++ b/tests/test_reviews.py
@@ -5,7 +5,8 @@ from tests import AmazonTestCase
 
 class ReviewsTestCase(AmazonTestCase):
     def test_parse_reviews_on_page(self):
-        p = self.amzn.lookup(ItemId="B0051QVF7A")
+        asin = "B0051QVF7A"
+        p = self.amzn.lookup(ItemId=asin)
         revs = self.amzn.reviews(URL=p.reviews_url)
         all_reviews = revs.parse_reviews_on_page()
         assert len(all_reviews), 10
@@ -17,6 +18,7 @@ class ReviewsTestCase(AmazonTestCase):
 
         # Ensure everything is found properly we don't really care about values though
         for dict_ in all_reviews:
+            assert dict_.to_dict()["asin"] == asin
             assert None not in dict_.to_dict().values()
 
     def test_reviews(self):

--- a/tests/test_search.py
+++ b/tests/test_search.py
@@ -28,11 +28,6 @@ class SearchTestCase(AmazonTestCase):
         for p in self.amzn.similarity_lookup(ItemId='B0051QVESA,B005DOK8NW'):
             self.verify_product(p)
 
-    @unittest.skip('There is no test here yet')
-    def test_browse_node_lookup(self):
-        # wtf is this for?
-        pass
-
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
The problem with the previous method was that we would have to go to an entirely new url each time, load up the html and then parse through it. This is a really time consuming process. Its much easier to load up all of the reviews on one page and parse them all in one shot. 

I think that we should keep the old method because it's still valid and can fill a niche, but for bulk data collection this will be the way to go.