### PR TITLE
add author reviews url to dict review output

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -192,6 +192,27 @@ By URL::
     >>> r.id
     R3MF0NIRI3BT1E
 
+Reviewer API
+~~~~~~~~~~~~
+This package also supports getting information about specific reviewers and the reviews 
+they have written over time. It is advisable to first look up a reviewer via another one
+of the products they have reviewed though. This situation will be improved in the future 
+though.
+
+Get reviews that a single reviewer has created::
+
+
+    r = self.amzn.review(Id="R3MF0NIRI3BT1E")
+    reviewer = self.amzn.reviewer(r.author_reviews_url)
+    all_reviews = reviewer.parse_reviews_on_page()
+
+Iterate to the authors next review page if they have one::
+
+    r = self.amzn.review(Id="R3MF0NIRI3BT1E")
+    reviewer = self.amzn.reviewer(r.author_reviews_url)
+    reviewer = self.amzn.reviewer(reviewer.next_page_url)
+    second_page_reviews = reviewer.parse_reviews_on_page()
+
 
 Authors
 =======

--- a/README.rst
+++ b/README.rst
@@ -149,11 +149,11 @@ View lists of reviews::
     >>> rs.url
     http://www.amazon.com/product-reviews/B0051QVF7A/ref=cm_cr_pr_top_sort_recent?&sortBy=bySubmissionDateDescending
 
-Quickly get a list of all reviews on a review page using `parse_reviews_on_page`::
+Quickly get a list of all reviews on a review page using the `all_reviews` property::
 
     >>> p = amzn.lookup(ItemId='B0051QVF7A')
     >>> rs = amzn.reviews(URL=p.reviews_url)
-    >>> all_reviews_on_page = rs.parse_reviews_on_page()
+    >>> all_reviews_on_page = rs.all_reviews
     >>> len(all_reviews_on_page)
     10
     >>> all_reviews_on_page[0].to_dict()["title"]
@@ -169,7 +169,7 @@ By ASIN/ItemId::
 
 
 For individual reviews use the `review` method. As a note this method is **NOT** suggested
-for use in bulk collection of reviews. Use `parse_reviews_on_page` instead.::
+for use in bulk collection of reviews. Use `all_reviews` instead.::
 
     >>> r = amzn.review(Id=rs.ids[0])
     >>> r.id
@@ -204,14 +204,14 @@ Get reviews that a single reviewer has created::
 
     r = self.amzn.review(Id="R3MF0NIRI3BT1E")
     reviewer = self.amzn.reviewer(r.author_reviews_url)
-    all_reviews = reviewer.parse_reviews_on_page()
+    all_reviews = reviewer.all_reviews
 
 Iterate to the authors next review page if they have one::
 
     r = self.amzn.review(Id="R3MF0NIRI3BT1E")
     reviewer = self.amzn.reviewer(r.author_reviews_url)
     reviewer = self.amzn.reviewer(reviewer.next_page_url)
-    second_page_reviews = reviewer.parse_reviews_on_page()
+    second_page_reviews = reviewer.all_reviews
 
 
 Authors

--- a/amazon_scraper/__init__.py
+++ b/amazon_scraper/__init__.py
@@ -1,20 +1,20 @@
 # -*- coding: utf-8 -*-
 from __future__ import absolute_import
-
-# load our version
-from .version import __version__
-
 import logging
 import re
 import urlparse
 import urllib
 import functools
 import time
+
 import requests
 from HTMLParser import HTMLParser
 from amazon.api import AmazonAPI
 import dateutil.parser
 from bs4 import BeautifulSoup
+
+from .version import __version__  # load our version
+
 
 log = logging.getLogger(__name__)
 
@@ -145,9 +145,12 @@ def rate_limit(api):
                     time.sleep(wait_time)
         api._last_query_time[0] = time.time()
 
+#This schema of imports is non-standard and should change. It will require some re-ordering of
+#functions inside the package though.
 from amazon_scraper.product import Product
 from amazon_scraper.reviews import Reviews
 from amazon_scraper.review import Review
+from amazon_scraper.reviewer import Reviewer
 
 
 class AmazonScraper(object):
@@ -159,6 +162,9 @@ class AmazonScraper(object):
 
     def review(self, Id=None, URL=None):
         return Review(self, Id, URL)
+
+    def reviewer(self, url):
+        return Reviewer(url)
 
     def lookup(self, URL=None, **kwargs):
         if URL:

--- a/amazon_scraper/review.py
+++ b/amazon_scraper/review.py
@@ -39,7 +39,6 @@ class Review(object):
             rate_limit(self.api)
             r = requests.get(self._URL, headers={'User-Agent':user_agent}, verify=False)
             r.raise_for_status()
-            #self._soup = BeautifulSoup(r.text, 'html.parser')
             self._soup = BeautifulSoup(r.text, 'html5lib')
         return self._soup
 

--- a/amazon_scraper/review.py
+++ b/amazon_scraper/review.py
@@ -1,6 +1,9 @@
 from __future__ import absolute_import
+from urlparse import urljoin
+
 import requests
 from bs4 import BeautifulSoup
+
 from amazon_scraper import (
     review_url,
     extract_review_id,
@@ -82,9 +85,6 @@ class Review(object):
 
     @property
     def author(self):
-        # http://www.amazon.com/review/R3MF0NIRI3BT1E
-        # http://www.amazon.com/review/RI3ARYEHW5DT5
-        # http://www.amazon.com/review/R2OD03CRAU7EDV
         vcard = self.soup.find('span', class_='reviewer vcard')
         if vcard:
             tag = vcard.find(class_='fn')
@@ -92,6 +92,16 @@ class Review(object):
                 author = unicode(tag.string)
                 return author
         return None
+
+    @property
+    def author_reviews_url(self):
+        try:
+            vcard = self.soup.find('span', class_='reviewer vcard')
+            path = vcard.find("a").attrs["href"]
+        except (AttributeError, KeyError):
+            return None
+        else:
+            return urljoin("http://amazon.com", path.replace("pdp", "cdp").replace("profile", "member-reviews"))
 
     @property
     def text(self):

--- a/amazon_scraper/reviewer.py
+++ b/amazon_scraper/reviewer.py
@@ -122,7 +122,7 @@ class Reviewer(object):
             raise ValueError(
                 "We cannot parse reviews that are not on a users' cdp/member-reviews page"
             )
-        self.all_reviews = None
+        self.all_reviews = []
         self._author = None
         self._next_page_url = None
         self._url = url
@@ -189,7 +189,9 @@ class Reviewer(object):
         The product information is parsed for its asin, and then the review part is found
         and then sent to the `ReviewerListedReview` object for further parsing.
         """
-        tmp = []
+        if self.all_reviews:
+            return self.all_reviews
+
         # First get all review ids on the page
         ids = self.soup.find_all("a", attrs={"name": re.compile(r"[A-Z0-9]{13}")})
         for id_ in ids:
@@ -202,6 +204,5 @@ class Reviewer(object):
             asin_tag = full_review_soup.find("a", attrs={"href": asin_regex})
             asin = asin_regex.search(asin_tag.attrs["href"]).groups()[0]
             # Now get the review
-            tmp.append(ReviewerListedReview(review_soup, asin, self.author, id_str, self.url))
-        self.all_reviews = tmp
+            self.all_reviews.append(ReviewerListedReview(review_soup, asin, self.author, id_str, self.url))
         return self.all_reviews

--- a/amazon_scraper/reviewer.py
+++ b/amazon_scraper/reviewer.py
@@ -1,0 +1,207 @@
+from __future__ import absolute_import
+import re
+from urlparse import urljoin
+
+from bs4 import BeautifulSoup
+import requests
+
+from amazon_scraper import (
+    get_review_date,
+    retry,
+    review_url,
+    user_agent,
+)
+
+RATINGS_MAPPING = {
+    "1.0 out of 5 stars": 0.2,
+    "2.0 out of 5 stars": 0.4,
+    "3.0 out of 5 stars": 0.6,
+    "4.0 out of 5 stars": 0.8,
+    "5.0 out of 5 stars": 1.0
+}
+
+
+class ReviewerListedReview(object):
+    """
+    Because individual reviews on the reviewer's list of reviews are difficult to parse we need to
+    sift out most of the information needed in the main Reviewer class and then send it here when
+    we find the HTML we need.
+    """
+    def __init__(self, soup, asin, author, id_, reviewer_profile_url):
+        self._asin = asin
+        self._author = author
+        self._date = None
+        self._id = id_
+        self._rating = None
+        self._text = None
+        self._title = None
+        self._soup = soup
+        self._review_url = None
+        self._reviewer_profile_url = reviewer_profile_url
+
+    @property
+    def asin(self):
+        return self._asin
+
+    @property
+    def author(self):
+        return self._author
+
+    @property
+    def author_reviews_url(self):
+        return self._reviewer_profile_url
+
+    @property
+    def date(self):
+        if not self._date:
+            date_tag = self._soup.find("nobr")
+            self._date = get_review_date(date_tag.text)
+        return self._date
+
+    @property
+    def id(self):
+        return self._id
+
+    @property
+    def rating(self):
+        if not self._rating:
+            rating_tag = self._soup.find("img", attrs={"title": re.compile("out of 5 stars")})
+            self._rating = RATINGS_MAPPING[rating_tag.attrs["title"]]
+        return self._rating
+
+    @property
+    def soup(self):
+        return self._soup
+
+    @property
+    def text(self):
+        if not self._text:
+            self._text = self._soup.find("div", class_="reviewText").text
+        return self._text
+
+    @property
+    def title(self):
+        if not self._title:
+            self._title = self._soup.find("b").text
+        return self._title
+
+    @property
+    def url(self):
+        if not self._review_url:
+            self._review_url = review_url(self._id)
+        return self._review_url
+
+    def to_dict(self):
+        return {
+            "asin": self.asin,
+            "author": self.author,
+            "author_reviews_url": self.author_reviews_url,
+            "date": self.date,
+            "id": self.id,
+            "rating": self.rating,
+            "text": self.text,
+            "title": self.title,
+            "url": self.url,
+        }
+
+
+class Reviewer(object):
+    """
+    Scrape reviews from a specific reviewer given the URL of all of their
+    amazon reviews
+
+    :param url: A url pointing to the reviewer's cdp/member-reviews list
+    """
+    def __init__(self, url):
+        if not (isinstance(url, str) or isinstance(url, unicode)):
+            raise ValueError(
+                "Our url {} cannot be of type {}. It must be a string".
+                format(url, type(url))
+            )
+        if "cdp/member-reviews" not in url:
+            raise ValueError(
+                "We cannot parse reviews that are not on a users' cdp/member-reviews page"
+            )
+        self.all_reviews = None
+        self._author = None
+        self._next_page_url = None
+        self._url = url
+        self._soup = None
+
+    @property
+    @retry()
+    def soup(self):
+        if not self._soup:
+            r = requests.get(self.url, headers={"User-Agent": user_agent})
+            r.raise_for_status()
+            self._soup = BeautifulSoup(r.text, "html5lib")
+        return self._soup
+
+    @property
+    def author(self):
+        if not self._author:
+            # This feels fragile but a text search didnt work unfortunately
+            author_tag = self.soup.find("b", class_="h1")
+            # rstrip the author text just to be safe
+            self._author = re.search(r"Written by\s*(.+)\s\n", author_tag.text).groups()[0].rstrip()
+        return self._author
+
+    @property
+    def next_page_url(self):
+        def check_for_next_page(tag):
+            if not tag:
+                self._next_page_url = None
+            else:
+                self._next_page_url = urljoin("http://amazon.com", tag.attrs["href"])
+
+        if not self._next_page_url:
+            generic_page_regex = re.compile(r"page=(\d{1,})")
+            current_page = generic_page_regex.search(self.url)
+            if not current_page:  # We are either on page 1 or there is no review pagination
+                # Look for page 2. If there is none then there are no more review pages
+                second_page = self.soup.find("a", attrs={"href": re.compile(r"page=2")})
+                check_for_next_page(second_page)
+            else:  # We are on some page > 1
+                page_number = int(current_page.groups()[0])
+                next_page = self.soup.find(
+                    "a", attrs={"href": re.compile(r"page={}".format(page_number + 1))}
+                )
+                check_for_next_page(next_page)
+        return self._next_page_url
+
+    @property
+    def reviewer_id(self):
+        return re.search(self.url, "member-reviews\/([A-Z0-9]+)\/").groups()[0]
+
+    @property
+    def url(self):
+        return self._url
+
+    def parse_reviews_on_page(self):
+        """
+        Parse all reviews created by the reviewer on the specific page.
+
+        There seem to be two HTML 'chunks' for a review. One is a part that includes the
+        review id and all other relevant information for the review like rating, title, and
+        text. The other is the product description which ends up above the actual review
+        information. We must parse both of these parts.
+
+        The product information is parsed for its asin, and then the review part is found
+        and then sent to the `ReviewerListedReview` object for further parsing.
+        """
+        tmp = []
+        # First get all review ids on the page
+        ids = self.soup.find_all("a", attrs={"name": re.compile(r"[A-Z0-9]{13}")})
+        for id_ in ids:
+            id_str  = id_.attrs["name"]
+            review_soup = id_.findParent()
+            asin_regex = re.compile(r"dp\/([A-Z0-9]{10})")
+            # Get the soup of the full review (Item photo and description included) and get the
+            # product's asin
+            full_review_soup = review_soup.findParent().findParent()
+            asin_tag = full_review_soup.find("a", attrs={"href": asin_regex})
+            asin = asin_regex.search(asin_tag.attrs["href"]).groups()[0]
+            # Now get the review
+            tmp.append(ReviewerListedReview(review_soup, asin, self.author, id_str, self.url))
+        self.all_reviews = tmp
+        return self.all_reviews

--- a/amazon_scraper/reviewer.py
+++ b/amazon_scraper/reviewer.py
@@ -112,20 +112,20 @@ class Reviewer(object):
 
     :param url: A url pointing to the reviewer's cdp/member-reviews list
     """
-    def __init__(self, url):
-        if not (isinstance(url, str) or isinstance(url, unicode)):
+    def __init__(self, URL):
+        if not (isinstance(URL, str) or isinstance(URL, unicode)):
             raise ValueError(
                 "Our url {} cannot be of type {}. It must be a string".
-                format(url, type(url))
+                format(URL, type(URL))
             )
-        if "cdp/member-reviews" not in url:
+        if "cdp/member-reviews" not in URL:
             raise ValueError(
                 "We cannot parse reviews that are not on a users' cdp/member-reviews page"
             )
-        self.all_reviews = []
+        self._all_reviews = []
         self._author = None
         self._next_page_url = None
-        self._url = url
+        self._url = URL
         self._soup = None
 
     @property
@@ -177,7 +177,8 @@ class Reviewer(object):
     def url(self):
         return self._url
 
-    def parse_reviews_on_page(self):
+    @property
+    def all_reviews(self):
         """
         Parse all reviews created by the reviewer on the specific page.
 
@@ -189,8 +190,8 @@ class Reviewer(object):
         The product information is parsed for its asin, and then the review part is found
         and then sent to the `ReviewerListedReview` object for further parsing.
         """
-        if self.all_reviews:
-            return self.all_reviews
+        if self._all_reviews:
+            return self._all_reviews
 
         # First get all review ids on the page
         ids = self.soup.find_all("a", attrs={"name": re.compile(r"[A-Z0-9]{13}")})
@@ -204,5 +205,5 @@ class Reviewer(object):
             asin_tag = full_review_soup.find("a", attrs={"href": asin_regex})
             asin = asin_regex.search(asin_tag.attrs["href"]).groups()[0]
             # Now get the review
-            self.all_reviews.append(ReviewerListedReview(review_soup, asin, self.author, id_str, self.url))
-        return self.all_reviews
+            self._all_reviews.append(ReviewerListedReview(review_soup, asin, self.author, id_str, self.url))
+        return self._all_reviews

--- a/amazon_scraper/reviews.py
+++ b/amazon_scraper/reviews.py
@@ -147,14 +147,15 @@ class Reviews(object):
         self._soup = None
 
     def parse_reviews_on_page(self):
-        tmp = []
+        if self.all_reviews:
+            return self.all_reviews
+
         for review_id in self.ids:
             try:
                 review = SubReview(self.soup, review_id, self.asin)
             except ValueError:
                 continue
-            tmp.append(review)
-        self.all_reviews = tmp
+            self.all_reviews.append(review)
         return self.all_reviews
 
     @property

--- a/amazon_scraper/reviews.py
+++ b/amazon_scraper/reviews.py
@@ -141,22 +141,23 @@ class Reviews(object):
             URL = reviews_url(extract_reviews_id(URL))
 
         self._asin = re.search(r"\/product-reviews\/(\w+)\/", URL).groups()[0]
-        self.all_reviews = []
+        self._all_reviews = []
         self.api = api
         self._URL = URL
         self._soup = None
 
-    def parse_reviews_on_page(self):
-        if self.all_reviews:
-            return self.all_reviews
+    @property
+    def all_reviews(self):
+        if self._all_reviews:
+            return self._all_reviews
 
         for review_id in self.ids:
             try:
                 review = SubReview(self.soup, review_id, self.asin)
             except ValueError:
                 continue
-            self.all_reviews.append(review)
-        return self.all_reviews
+            self._all_reviews.append(review)
+        return self._all_reviews
 
     @property
     @retry()

--- a/amazon_scraper/reviews.py
+++ b/amazon_scraper/reviews.py
@@ -35,6 +35,7 @@ class SubReview(object):
 
         self._asin = product_asin
         self._author = None
+        self._author_reviews_url = None
         self._date = None
         self._rating = None
         self._text = None
@@ -58,6 +59,20 @@ class SubReview(object):
     @property
     def author(self):
         return self._parse_generic_property(self._author, "a", "author")
+
+    @property
+    def author_reviews_url(self):
+        """
+        Get the page pointing to the author's reviews
+        """
+        if not self._author_reviews_url:
+            author_reviews_url = self.soup.find("a", class_=re.compile("author"))
+            if author_reviews_url:
+                tmp_url = urljoin("http://amazon.com", author_reviews_url.attrs["href"])
+                self._author_reviews_url = tmp_url.replace("pdp", "cdp").replace("profile", "member-reviews")
+            else:
+                self._author_reviews_url = author_reviews_url
+        return self._author_reviews_url
 
     @property
     def date(self):
@@ -100,6 +115,7 @@ class SubReview(object):
         return {
             "asin": self.asin,
             "author": self.author,
+            "author_reviews_url": self.author_reviews_url,
             "date": self.date,
             "id": self.id,
             "rating": self.rating,
@@ -131,12 +147,14 @@ class Reviews(object):
         self._soup = None
 
     def parse_reviews_on_page(self):
+        tmp = []
         for review_id in self.ids:
             try:
                 review = SubReview(self.soup, review_id, self.asin)
             except ValueError:
                 continue
-            self.all_reviews.append(review)
+            tmp.append(review)
+        self.all_reviews = tmp
         return self.all_reviews
 
     @property

--- a/tests/test_reviewer.py
+++ b/tests/test_reviewer.py
@@ -1,0 +1,46 @@
+from __future__ import absolute_import
+
+from tests import AmazonTestCase
+
+
+class ReviewerTestCase(AmazonTestCase):
+    def test_parse_reviews_on_page(self):
+        r = self.amzn.review(Id="R3MF0NIRI3BT1E")
+        assert "author_reviews_url" in r.to_dict()
+        reviewer = self.amzn.reviewer(r.to_dict()["author_reviews_url"])
+        all_reviews = reviewer.parse_reviews_on_page()
+        keys = ["asin", "author", "author_reviews_url", "date", "id", "rating", "text", "title", "url"]
+        for review in all_reviews:
+            review_dict = review.to_dict()
+            assert "rating" in review_dict
+            assert 0.2 <= review_dict["rating"] <= 1.0
+            for k, v in review_dict.iteritems():
+                assert k in keys, k
+                assert v  # Assert our values are non-null
+
+    def test_next_page_url(self):
+        r = self.amzn.review(Id="R3MF0NIRI3BT1E")
+        assert "author_reviews_url" in r.to_dict()
+        reviewer = self.amzn.reviewer(r.to_dict()["author_reviews_url"])
+        next_page_url = reviewer.next_page_url
+        assert "page=2" in next_page_url
+        reviewer = self.amzn.reviewer(next_page_url)
+        next_page_url = reviewer.next_page_url
+        assert "page=3" in next_page_url
+
+    def test_next_page_url_with_no_next(self):
+        reviewer = self.amzn.reviewer(
+            "http://www.amazon.com/gp/cdp/member-reviews/A2HX6HJ51UEROW/ref=cm_cr_pr_pdp?ie=UTF8"
+        )
+        next_page_url = reviewer.next_page_url
+        assert next_page_url is None
+
+    def test_reviewer_with_null_constructor_input(self):
+        self.assertRaises(ValueError, self.amzn.reviewer, None)
+
+    def test_reviewer_with_profile_url(self):
+        self.assertRaises(
+            ValueError,
+            self.amzn.reviewer,
+            "http://www.amazon.com/gp/pdb/profile/A2HX6HJ51UEROW/ref=cm_cr_pr_pdp?ie=UTF8"
+        )

--- a/tests/test_reviewer.py
+++ b/tests/test_reviewer.py
@@ -4,11 +4,11 @@ from tests import AmazonTestCase
 
 
 class ReviewerTestCase(AmazonTestCase):
-    def test_parse_reviews_on_page(self):
+    def test_all_reviews(self):
         r = self.amzn.review(Id="R3MF0NIRI3BT1E")
         assert "author_reviews_url" in r.to_dict()
         reviewer = self.amzn.reviewer(r.to_dict()["author_reviews_url"])
-        all_reviews = reviewer.parse_reviews_on_page()
+        all_reviews = reviewer.all_reviews
         keys = ["asin", "author", "author_reviews_url", "date", "id", "rating", "text", "title", "url"]
         for review in all_reviews:
             review_dict = review.to_dict()

--- a/tests/test_reviews.py
+++ b/tests/test_reviews.py
@@ -4,11 +4,11 @@ import os
 from tests import AmazonTestCase
 
 class ReviewsTestCase(AmazonTestCase):
-    def test_parse_reviews_on_page(self):
+    def test_all_reviews(self):
         asin = "B0051QVF7A"
         p = self.amzn.lookup(ItemId=asin)
         revs = self.amzn.reviews(URL=p.reviews_url)
-        all_reviews = revs.parse_reviews_on_page()
+        all_reviews = revs.all_reviews
         assert len(all_reviews), 10
 
         # Ensure all review ids are represented


### PR DESCRIPTION
Fix a bug with parse_reviews_on_page where it would create duplicate reviews on the review list if we had already called the function. Also add a new dictionary entry for getting a url pointing to the list of the author's reviews.