### PR TITLE
make trailing slash in _extract_asin_regexp optional

### DIFF
--- a/amazon_scraper/__init__.py
+++ b/amazon_scraper/__init__.py
@@ -35,7 +35,7 @@ user_agent = 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_9_4) AppleWebKit/537.36 
 
 amazon_base = 'http://www.amazon.com'
 
-_extract_asin_regexp = re.compile(r'(/dp/|/gp/product/)(?P<asin>[^/]+)/')
+_extract_asin_regexp = re.compile(r'(/dp/|/gp/product/)(?P<asin>[^/]+)/?')
 _process_rating_regexp = re.compile(r'([\d\.]+) out of [\d\.]+ stars', flags=re.I)
 _extract_reviews_asin_regexp = re.compile(r'/product-reviews/(?P<asin>[^/]+)', flags=re.I)
 _extract_review_id_regexp = re.compile(r'/review/(?P<id>[^/]+)', flags=re.I)

--- a/tests/test_user_reviews.py
+++ b/tests/test_user_reviews.py
@@ -19,7 +19,7 @@ class UserReviewsTestCase(AmazonTestCase):
         reviewer = self.amzn.user_reviews(URL=r.user_reviews_url)
 
         for review in islice(reviewer.brief_reviews, 5):
-            print review.id
+            print(review.id)
             assert review.id
             fr = review.full_review()
             assert fr.id == review.id, (fr.id, review.id)


### PR DESCRIPTION
Calling the lookup method with a URL like 'http://www.amazon.com/dp/B0051QVF7A' fails because the regular expression expects a slash after the ASIN. The test url works on Amazon and is not redirected.

I ran the tests locally and the test results are the same before and after the change including failures and errors:
FAILED (failures=9, errors=7, skipped=10)

As far as I can tell the change did not introduce errors.